### PR TITLE
fix: DomainToAddressUpdate events

### DIFF
--- a/src/custom_resolutions.ts
+++ b/src/custom_resolutions.ts
@@ -65,11 +65,8 @@ export default function transform({ header, events }: Block) {
 
   return events.map(({ event }: EventWithTransaction) => {
     const key = BigInt(event.keys[0]);
-    // We support both Cairo 0 and Cairo 1 style of the same event
-    if (
-      key === SELECTOR_KEYS.CUSTOM_RESOLVER_ADDRESS_UPDATE ||
-      key === SELECTOR_KEYS.OLD_DOMAIN_ADDR_UPDATE
-    ) {
+    // Cairo0 support
+    if (key === SELECTOR_KEYS.OLD_DOMAIN_ADDR_UPDATE) {
       const domainLength = Number(event.data[0]);
       const domainSlice = decodeDomainSlice(
         event.data.slice(1, 1 + domainLength).map(BigInt)
@@ -99,8 +96,38 @@ export default function transform({ header, events }: Block) {
           },
         },
       };
+    } else if (key === SELECTOR_KEYS.CUSTOM_RESOLVER_ADDRESS_UPDATE) {
+      // Cairo1 support
+      const domainLength = Number(event.keys[1]);
+      const domainSlice = decodeDomainSlice(
+        event.keys.slice(2, 2 + domainLength).map(BigInt)
+      );
+      const targetAddress = event.data[0];
+      const resolver = event.fromAddress;
+      // 'field' will be used in the future to handle resolvings of more data
+      // like your avatar or other blockchain addresses. Existing custom resolvers
+      // only return a starknet address (equivalent to the starknet field written
+      // on your identity on the new architecture).
+      return {
+        entity: { resolver, domain_slice: domainSlice, field: "starknet" },
+        update: {
+          $set: {
+            resolver,
+            domain_slice: domainSlice,
+            field:
+              "0x000000000000000000000000000000000000000000000000737461726b6e6574", // starknet encoded
+            value: targetAddress,
+            creation_date: {
+              $cond: [
+                { $not: ["$creation_date"] },
+                timestamp,
+                "$creation_date",
+              ],
+            },
+          },
+        },
+      };
     } else if (key === SELECTOR_KEYS.CUSTOM_RESOLVER_UPDATE) {
-      console.log("EVENT A:", event);
       const domainLength = Number(event.keys[1]);
       const domainSlice = decodeDomainSlice(
         event.keys.slice(2, 2 + domainLength).map(BigInt)


### PR DESCRIPTION
This PR fixes the indexation of `DomainToAddressUpdate` events. The cairo1 event has the domain in `keys`, not in `data`